### PR TITLE
Correct minor typos and formatting in Privacy Policy

### DIFF
--- a/privacy-policy/en.md
+++ b/privacy-policy/en.md
@@ -1,7 +1,7 @@
 ## Privacy policy
 This project is part of a scientific thesis to earn the degree of Bachelor of Science. To protect private data, we have used the Minimal Data Usage principle and the Offline First principle. Accordingly, all personal data is stored only locally on the device. In addition, we do not collect any data that is not necessary for the use of the app.
 
-## Responsiblility 
+## Responsibility
 Responsible for the development of the app and the our study server is *Niklas Bittner*, student of computer science at the Technical University of Darmstadt. The main supervisor of this work is *Alexander Heinrich, M.Sc* as a PhD student and research assistant at the Technical University of Darmstadt at the Secure Mobile Networking Lab.
 
 Address: Alexander Heinrich
@@ -9,7 +9,7 @@ Pankratiusstraße 2,
 64289 Darmstadt
 
 ## Study
-There is also the **voluntary** possibility to participate in a scientific study. In this study we would like to find out how often people are threatened by tracking (stalking). Whether Apple's Find My devices are actually used for tracking  people. And ultimately, how well we can protect people from this through our app. 
+There is also the **voluntary** possibility to participate in a scientific study. In this study we would like to find out how often people are threatened by tracking (stalking). Whether Apple's Find My devices are actually used for tracking people. And ultimately, how well we can protect people from this through our app. 
 
 In case of consent, the app then sends anonymized data to our server, which is later analyzed and published as part of the study. With the help of this data, it is not possible for us to identify participants in the study.
 
@@ -56,9 +56,9 @@ The data on your device is necessary for the app to work.
 The data on the server is only for voluntary participation in our study.
 
 ## Sharing of user data 
-Identifiable user data is not shared with ourselves and not with any thrid party. 
+Identifiable user data is not shared with ourselves and not with any third party. 
 
-Anonymized user data gathered during our study can be published in an aggregated form. This data does not allow to  identify any user. 
+Anonymized user data gathered during our study can be published in an aggregated form. This data does not allow to identify any user. 
 
 ## Duration of storage 
 
@@ -73,7 +73,7 @@ According to the GDPR, there is a right to information. This allows you to view 
 However, since we do not store or process personal data, we cannot show it to you.
 
 ### Deletion of data
-To delete all personal data, it is sufficient to delete the app. Data that was collected voluntarily for the purpose of the study cannot be deleted, as it is not identifiable
+To delete all personal data, it is sufficient to delete the app. Data that was collected voluntarily for the purpose of the study cannot be deleted, as it is not identifiable.
 
 ### Right of objection
 You have the right to object to the use of the data. If you no longer wish to participate in the study, simply deactivate the corresponding setting.


### PR DESCRIPTION
I corrected minor typos and formatting (mostly repeated double spaces in "the middle" of sentences) in Privacy Policy.