### PR TITLE
Enable local encrypted Seedvault backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,12 +32,14 @@
 
     <application
         android:name=".ATTrackingDetectionApplication"
-        android:allowBackup="false"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.ATTrackingDetection">
+        android:theme="@style/Theme.ATTrackingDetection"
+        tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".ui.TrackingActivity"
             android:excludeFromRecents="true"

--- a/app/src/main/res/xml/backup.xml
+++ b/app/src/main/res/xml/backup.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    
+    <include
+        domain="sharedpref"
+        path="."
+        requireFlags="clientSideEncryption" />
+    
+    <include
+        domain="database"
+        path="."
+        requireFlags="clientSideEncryption" />
+        
+</full-backup-content>


### PR DESCRIPTION
I've made 2 edits to enable local encrypted Seedvault backups, according to its [FAQ Wiki page](https://github.com/seedvault-app/seedvault/wiki/FAQ) - if the appropriate use case of AirGuard is compatible with Seedvault. (I tried my best to emulate the styling in the new XML file.)

Seedvault is a system-level app that allows users to back up system settings and compatible app data on various aftermarket Android OSs, such as: GrapheneOS, CalyxOS, and LineageOS (also DivestOS). Users with Seedvault can transfer AirGuard device detection history to a new device via local encrypted backups, saving a lot of time during setup.

(Also, there currently isn't a way to import/export AirGuard data.)