### PR TITLE
Fixes for issue #20

### DIFF
--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/OnboardingActivity.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/OnboardingActivity.kt
@@ -216,8 +216,8 @@ class OnboardingActivity : AppIntro() {
             AlertDialog.Builder(this).setTitle(R.string.permission_required)
                 .setIcon(R.drawable.ic_baseline_error_outline_24)
                 .setMessage(R.string.permission_required_message)
-                .setPositiveButton(R.string.ok_button) { _: DialogInterface, _: Int ->
-                    finish()
+                .setPositiveButton(R.string.ok_button) { dialog, _ ->
+                    dialog.dismiss()
                 }
                 .create()
                 .show()

--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/OnboardingActivity.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/OnboardingActivity.kt
@@ -2,7 +2,6 @@ package de.seemoo.at_tracking_detection.ui
 
 import android.Manifest
 import android.app.AlertDialog
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -31,6 +30,8 @@ class OnboardingActivity : AppIntro() {
     lateinit var backgroundWorkScheduler: BackgroundWorkScheduler
 
     var permission: String? = null
+
+    private var dialog: AlertDialog? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -212,14 +213,16 @@ class OnboardingActivity : AppIntro() {
     private fun handleRequiredPermission(permissionName: String) {
         if (permissionName == Manifest.permission.ACCESS_BACKGROUND_LOCATION) {
             sharedPreferences.edit().putBoolean("use_location", false).apply()
-        } else {
-            AlertDialog.Builder(this).setTitle(R.string.permission_required)
+        } else if (dialog?.isShowing != true) {
+            AlertDialog.Builder(this)
+                .setTitle(R.string.permission_required)
                 .setIcon(R.drawable.ic_baseline_error_outline_24)
                 .setMessage(R.string.permission_required_message)
                 .setPositiveButton(R.string.ok_button) { dialog, _ ->
                     dialog.dismiss()
                 }
                 .create()
+                .also { dialog = it }
                 .show()
         }
     }


### PR DESCRIPTION
# Issue 1
This is fixed by dismissing the dialog rather than closing the activity entirely. I am assuming this is the intended flow, however, we can also dismiss the activity. We just need to ensure the fix for issue 2 is in place as I believe opening the second dialog after killing the activity is the root cause.

# Issue 2
To fix duplicate dialogs I've just stored a reference to a dialog once it's opened. If the dialog is still showing we don't show another.  This is necessary as onUserDeniedPermission seems to be called several times when dismissing a permission prompt.

Please let me know what you think.