### PR TITLE
Clean up dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,6 @@ apiProperties.load(new FileInputStream(apiPropertiesFile))
 
 android {
     compileSdkVersion 31
-    buildToolsVersion "30.0.3"
 
     buildFeatures {
         viewBinding true
@@ -26,8 +25,6 @@ android {
         targetSdkVersion 31
         versionCode 19
         versionName "1.1.0"
-
-        multiDexEnabled true
 
         buildConfigField "String", "API_KEY", apiProperties["API_KEY"]
         buildConfigField "String", "API_BASE_ADDRESS", apiProperties["API_BASE_ADDRESS"]
@@ -62,7 +59,7 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 
@@ -71,10 +68,8 @@ aboutLibraries {
 }
 
 dependencies {
-    implementation 'androidx.work:work-testing:2.7.1'
-    debugImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation 'androidx.multidex:multidex:2.0.1'
+
     implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation 'androidx.work:work-runtime-ktx:2.7.1'
     implementation 'androidx.core:core-ktx:1.7.0'
@@ -99,7 +94,6 @@ dependencies {
     implementation "com.google.dagger:hilt-android:$hilt_version"
     implementation 'androidx.hilt:hilt-work:1.0.0'
     implementation 'androidx.hilt:hilt-navigation-fragment:1.0.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     implementation 'com.github.AppIntro:AppIntro:6.1.0'
 
@@ -115,7 +109,6 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
-    testImplementation "androidx.room:room-testing:$room_version"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
- Use default (latest) build tools
- Remove unnecessary Multidex dependency/config (it works by default in Android 5.0+)
- Remove some unused dependencies