### PR TITLE
fix typos and unify text in de/strings.xml

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,7 +6,7 @@
     <string name="title_settings">Einstellungen</string>
     <string name="title_debug">Debug</string>
     <string name="title_feedback">Feedback</string>
-    <string name="title_tracking">{deviceAddress} folgt dir</string>
+    <string name="title_tracking">{deviceAddress} folgt Dir</string>
     <string name="title_devices_tracking">Gerät {deviceAddress}</string>
     <string name="title_device_map">Alle Geräte</string>
     <string name="title_devices">Geräte</string>
@@ -21,16 +21,16 @@
     <string name="device_item_first_discovery">Erste Entdeckung</string>
     <string name="devices_swipe">Zum Entfernen wischen</string>
     <string name="channel_name">Tracking-Erkennung</string>
-    <string name="channel_description">Warnt dich vor "Find My" Geräten, die dich evtl. verfolgen</string>
-    <string name="devices_list_empty">Sobald AirGuard einen AirTag oder ein anderes "Find My"-Gerät in deiner Nähe findet, wird es hier aufgelistet. Die Liste wird daher auch Geräte enthalten, die zufällig in deiner Umgebung waren und dich nicht verfolgen. Du erhälst eine Benachrichtigung für Geräte, die dich verfolgen.</string>
-    <string name="ignored_device_list_empty">Immer wenn du eine Benachrichtigung erhalten hast, dass du von einem dir bekannten Gerät (z. B. einem AirTag, den Sie besitzen) verfolgt wirst, dann kannst du diese ignorieren. Diese ignorierten Geräte werden hier angezeigt. Denken Sie daran: Ein AirTag ändert seine Bluetooth-Adresse einmal am Tag. Ein bekannter AirTag wird also nach einem Tag als ein neuer angezeigt.</string>
+    <string name="channel_description">Warnt dich vor "Find My"-Geräten, die dich evtl. verfolgen</string>
+    <string name="devices_list_empty">Sobald AirGuard einen AirTag oder ein anderes "Find My"-Gerät in Deiner Nähe findet, wird es hier aufgelistet. Die Liste wird daher auch Geräte enthalten, die zufällig in Deiner Umgebung waren und dich nicht verfolgen. Du erhältst eine Benachrichtigung für Geräte, die dich verfolgen.</string>
+    <string name="ignored_device_list_empty">Immer wenn Du eine Benachrichtigung erhalten hast, dass Du von einem Dir bekannten Gerät (z.B. einem AirTag, den Du besitzt) verfolgt wirst, dann kannst Du diese ignorieren. Diese ignorierten Geräte werden hier angezeigt. Denke daran: Ein AirTag ändert seine Bluetooth-Adresse einmal am Tag. Ein bekannter AirTag wird also nach einem Tag als ein neuer angezeigt.</string>
     <string name="settings_use_location_summary">Aktivieren, um detailliertere Standortinformationen bei einer Warnung zu erhalten</string>
     <string name="settings_use_location_title">Standort nutzen</string>
-    <string name="error_requesting_location_permission">Fehler beim Anfragen der Berechtigung im Hintergrund auf den Gerätestandort zugreifen zu dürfen</string>
+    <string name="error_requesting_location_permission">Fehler beim Anfragen der Berechtigung, im Hintergrund auf den Gerätestandort zugreifen zu dürfen</string>
     <string name="tracking_locate_at_title">Ton abspielen</string>
     <string name="tracking_locate_at_subtitle">AirTag lokalisieren</string>
     <string name="permissions_location_title">Standort im Hintergrund</string>
-    <string name="permission_location_message">Wenn Du diese Berechtigung erteilst, kannst Du detailliertere Standortinformationen zu einem AirTag oder "Find My"-Gerät zu erhalten, welches dich verfolgt. Diese Berechtigung ist optional.</string>
+    <string name="permission_location_message">Wenn Du diese Berechtigung erteilst, kannst Du detailliertere Standortinformationen zu einem AirTag oder "Find My"-Gerät erhalten, welches dich verfolgt. Diese Berechtigung ist optional.</string>
     <string name="ok_button">OK</string>
     <string name="tracking_feedback_title">Feedback</string>
     <string name="tracking_feedback_subtitle">Mehr Informationen mitteilen</string>
@@ -52,26 +52,26 @@
     <string name="onboarding_share_data_title">Statistikdaten teilen</string>
     <string name="onboarding_share_data_switch">Teile Statistikdaten</string>
     <string name="onboarding_share_data_description">
-        Du kannst uns helfen, AirGuard zu verbessern, indem du einige Statistikdaten teilst. Bei Zustimmung werden diese Daten täglich geteilt: <b>Gerätetyp</b>
+        Du kannst uns helfen, AirGuard zu verbessern, indem Du einige Statistikdaten teilst. Bei Zustimmung werden diese Daten täglich geteilt: <b>Gerätetyp</b>
         - Wir werden einige Informationen über die entdeckten Geräte sammeln, wie den <b>Gerätetyp</b>, den <b>RSSI-Wert</b> (Signalstärke) und das <b>Datum und die Uhrzeit</b> der Entdeckung \n\n
         - Wie viele <b>Benachrichtigungen</b> angezeigt wurden, das <b>Datum und die Uhrzeit</b> der Benachrichtigung sowie das <b>Benutzerfeedback</b>, das gegeben werden kann \n\n
         Wir werden <b>KEINE</b> Standorte oder Daten, die es uns ermöglichen könnten, dich zu identifizieren, wie Geräteadressen etc. teilen.</string>
-    <string name="onboarding_1_description">AirGuard benachrichtigt dich, falls du von einem Airtag oder "Find My"-Gerät verfolgt wirst.</string>
+    <string name="onboarding_1_description">AirGuard benachrichtigt dich, falls Du von einem Airtag oder "Find My"-Gerät verfolgt wirst.</string>
     <string name="onboarding_2_title">Standortberechtigung</string>
-    <string name="onboarding_2_description">AirGuard benötigt die Berechtigung, auf Ihren Standort zuzugreifen, um über Bluetooth Low Energy (LE) nach umliegenden AirTags suchen zu dürfen. Sie müssen diese Berechtigung erteilen, um AirGuard zu verwenden.</string>
+    <string name="onboarding_2_description">AirGuard benötigt die Berechtigung, auf Deinen Standort zuzugreifen, um über Bluetooth Low Energy (LE) nach umliegenden AirTags suchen zu dürfen. Du musst diese Berechtigung erteilen, um AirGuard zu verwenden.</string>
     <string name="onboarding_ignore_battery_optimization_title">Batterie-Optimierung</string>
     <string name="onboarding_ignore_battery_optimization_description">Um zu verhindern, dass AirGuard im Hintergrund beendet wird, müssen wir die Batterieoptimierung deaktivieren!</string>
     <string name="onboarding_ignore_battery_optimization">Batterie-Optimierung verhindern</string>
     <string name="onboarding_4_title">Berechtigung für den Standort im Hintergrund</string>
-    <string name="onboarding_4_description">"Wenn Sie einen detaillierteren Standortverlauf sehen möchten, ist die Berechtigung erforderlich, im Hintergrund auf den Standort zugreifen zu dürfen. Dies ermöglicht AirGuard konstant auf den Standort zuzugreifen, auch wenn AirGuard gerade geschlossen ist. Die Funktion ist optional. AirGuard verwendet die Standortdaten nur lokal, sie verlassen das Gerät nicht."</string>
+    <string name="onboarding_4_description">"Wenn Du einen detaillierteren Standortverlauf sehen möchtest, ist die Berechtigung erforderlich, im Hintergrund auf den Standort zugreifen zu dürfen. Dies ermöglicht AirGuard konstant auf den Standort zuzugreifen, auch wenn AirGuard gerade geschlossen ist. Die Funktion ist optional. AirGuard verwendet die Standortdaten nur lokal, sie verlassen das Gerät nicht."</string>
     <string name="onboarding_5_title">Fertig!</string>
     <string name="settings_theme_system_default">Systemstandard</string>
     <string name="settings_theme_dark">Dunkel</string>
     <string name="settings_theme_light">Hell</string>
-    <string name="settings_use_low_power_ble_summary">Wenn aktiviert, wird nur Bluetooth Low Power Scan verwendet, um in der Nähe befindliche AirTags zu erkennen.<b>WARNUNG</b>: Dies kann dazu führen, dass einige Geräte nicht erkannt werden.</string>
+    <string name="settings_use_low_power_ble_summary">Wenn aktiviert, wird nur Bluetooth Low Power Scan verwendet, um in der Nähe befindliche AirTags zu erkennen. <b>WARNUNG</b>: Dies kann dazu führen, dass einige Geräte nicht erkannt werden.</string>
     <string name="settings_use_low_power_ble_title">Low-Power-Scan verwenden</string>
     <string name="tracking_device_not_connectable">Dieses Gerät kann keinen Ton abspielen.</string>
-    <string name="tracking_info">Scanne diesen AirTag mit deinem Telefon über NFC, um weitere Informationen zu erhalten.</string>
+    <string name="tracking_info">Scanne diesen AirTag mit Deinem Telefon über NFC, um weitere Informationen zu erhalten.</string>
     <string name="info">Informationen</string>
     <string name="settings_app_theme_title">App-Design</string>
     <string name="settings_app_theme_summary">Wähle ein Design</string>
@@ -79,11 +79,11 @@
     <string name="settings_third_party_libraries_summary">Zeigt eine Liste aller verwendeten Bibliotheken von Drittanbietern und deren Lizenzen an</string>
     <string name="onboarding_share_data_no">Nein</string>
     <string name="onboarding_share_data_yes">Ja</string>
-    <string name="onboarding_share_data_dialog">Du musst entscheiden, ob du anonymisierte Daten teilen willst oder nicht.</string>
+    <string name="onboarding_share_data_dialog">Du musst entscheiden, ob Du anonymisierte Daten teilen willst oder nicht.</string>
     <string name="device_name_find_my_device">"Find My"-Gerät %s</string>
-    <string name="notification_text">Öffnen, um weitere Informationen zu erhalten. Ein Gerät ist dir für mindestens 30 Minuten gefolgt.</string>
+    <string name="notification_text">Öffnen, um weitere Informationen zu erhalten. Ein Gerät ist Dir für mindestens 30 Minuten gefolgt.</string>
     <string name="notification_title">Ein Tracker wurde entdeckt!</string>
-    <string name="map_empty_text">Es wurden noch keine Geräte gefunden. Jedes Mal, wenn ein Gerät entdeckt wird, wird sein Standort auf der Karte angezeigt. Dies bedeutet nicht, dass jemand Sie an jedem Standort geortet hat. In den meisten Fällen werden Sie Geräte von anderen in öffentlichen Verkehrsmitteln oder von einem Ihrer Nachbarn finden.</string>
+    <string name="map_empty_text">Es wurden noch keine Geräte gefunden. Jedes Mal, wenn ein Gerät entdeckt wird, wird sein Standort auf der Karte angezeigt. Dies bedeutet nicht, dass jemand dich an jedem Standort geortet hat. In den meisten Fällen wirst Du Geräte von anderen in öffentlichen Verkehrsmitteln oder von einem Deiner Nachbarn finden.</string>
     <string name="beacons">Signale</string>
     <string name="dashboard_tile_change">+%d</string>
     <string name="device_name_airtag">AirTag %s</string>
@@ -94,9 +94,9 @@
     <string name="find_my_device_icon">"Find My"-Geräte-Icon</string>
     <string name="location_sample_image">Standortbeispiel-Bild</string>
     <string name="location_permission_title">Standortzugriff</string>
-    <string name="location_permission_message">Diese App benötigt die Berechtigung auf deinen Standort zugreifen zu dürfen, um Bluetooth-Scans für AirTags und andere "Find My" Geräte zu ermöglichen, auch wenn die App geschlossen oder nicht in Gebrauch ist. Außerdem kannst du der App optional erlauben einen Standort verlauf anzuzeigen, wenn du verfolgt werden solltest.</string>
+    <string name="location_permission_message">Diese App benötigt die Berechtigung, auf Deinen Standort zugreifen zu dürfen, um Bluetooth-Scans für AirTags und andere "Find My"-Geräte zu ermöglichen, auch wenn die App geschlossen oder nicht in Gebrauch ist. Außerdem kannst Du der App optional erlauben, einen Standortverlauf anzuzeigen, wenn Du verfolgt werden solltest.</string>
     <string name="permissions_background_location_title">Standort im Hintergrund</string>
-    <string name="permission_background_location_message">Wenn Du diese Berechtigung erteilst, kannst Du detailliertere Standortinformationen zu einem AirTag oder "Find My"-Gerät zu erhalten, welches dich verfolgt. Diese Berechtigung ist optional.</string>
+    <string name="permission_background_location_message">Wenn Du diese Berechtigung erteilst, kannst Du detailliertere Standortinformationen zu einem AirTag oder "Find My"-Gerät erhalten, welches dich verfolgt. Diese Berechtigung ist optional.</string>
     <string name="devices_edit_title">Namen ändern</string>
     <string name="cancel_button">Abbruch</string>
     <string name="devices_alter_removed">"%s" wurde entfernt</string>
@@ -105,21 +105,21 @@
     <string name="grant_permission">Berechtigung erteilen</string>
     <string name="cancel">Abbrechen</string>
     <string name="no_button">Nein Danke</string>
-    <string name="twitter_description">Sieh dir unser Twitter an</string>
+    <string name="twitter_description">Sieh Dir unser Twitter an</string>
     <string name="twitter">Twitter</string>
     <string name="dashboard_scan_fab_description">Suche nach Geräten!</string>
     <string name="dashboard_scan_fab">Manueller Scan</string>
     <string name="onboarding_scan_title">Bluetooth Suche</string>
-    <string name="onboarding_scan_description">Um die Umgebung nach Tracking-Geräten zu scannen, benötigen wir die Erlaubnis nach Bluetooth-Geräten zu suchen!</string>
+    <string name="onboarding_scan_description">Um die Umgebung nach Tracking-Geräten zu scannen, benötigen wir die Erlaubnis, nach Bluetooth-Geräten zu suchen!</string>
     <string name="onboarding_connect_title">Verbinden mit Bluetooth-Geräten</string>
-    <string name="onboarding_connect_description">Wenn ein Tracking-Gerät gefunden wird, gibt AirGuard Ihnen die Möglichkeit, einen Ton darauf abzuspielen. Dafür benötigen wir die Erlaubnis, uns mit diesem Gerät zu verbinden!</string>
+    <string name="onboarding_connect_description">Wenn ein Tracking-Gerät gefunden wird, gibt AirGuard Dir die Möglichkeit, einen Ton darauf abzuspielen. Dafür benötigen wir die Erlaubnis, uns mit diesem Gerät zu verbinden!</string>
     <string name="scan_title">Manueller Scan</string>
     <string name="scan_result_item_image_description">"Scanergebnis Element "</string>
-    <string name="scan_result_no_devices">Keine Tracking-Geräte wurden gefunden. Sie sind sicher!</string>
+    <string name="scan_result_no_devices">Keine Tracking-Geräte wurden gefunden. Du bist sicher!</string>
     <string name="ble_service_connection_error">Verbindung zum Gerät fehlgeschlagen!</string>
     <string name="yes_button">Ja</string>
     <string name="scan_enable_bluetooth_title">Bluetooth Suche</string>
-    <string name="scan_enable_bluetooth_message">Bluetooth muss eingeschaltet sein um nach Bluetooth Gräten suchen zu können!</string>
+    <string name="scan_enable_bluetooth_message">Bluetooth muss eingeschaltet sein, um nach Bluetooth Gräten suchen zu können!</string>
     <string name="risk_level_low">Kein Risiko</string>
     <string name="risk_level_medium">Mittleres Risiko</string>
     <string name="risk_level_high">Hohes Risiko</string>
@@ -128,26 +128,26 @@
     <string name="last_scan_info">Letzter Scan: %s</string>
     <string name="last_discovery">Letzter Tracker gefunden am %s</string>
     <string name="notification_help">
-        • Suche den Tracker manuell und spiele anschließend ein Ton ab \n<br />
-        • Deaktiviere den Tracker indem du die Batterie entfernst \n<br />
+        • Suche den Tracker manuell und spiele anschließend einen Ton ab \n<br />
+        • Deaktiviere den Tracker indem Du die Batterie entfernst \n<br />
         • Bringe das Gerät zur Polizei und erstatte Anzeige\n<br />
-        • Stelle sicher, dass du dich nicht an einen anderen Ort begibst bevor du den Tracker gefunden hast\n<br />
+        • Stelle sicher, dass Du dich nicht an einen anderen Ort begibst bevor Du den Tracker gefunden hast\n<br />
     </string>
     <string name="i_got_a_notification_what_should_i_do">Ich habe eine Benachrichtigung bekommen, was soll ich machen?</string>
 
     <string name="find_tracker_help">
-        • Falsche Alarme sind möglich. Es kann sein, dass jemand in deiner Nähe einen AirTag verwendet.  \n<br />
-        • Wenn du mehrere Benachrichtigungen an verschiedenen Tagen erhalten hast, dann ist das Risiko hoch. Versuche den Tracker klingeln zu lassen.
+        • Falsche Alarme sind möglich. Es kann sein, dass jemand in Deiner Nähe einen AirTag verwendet.  \n<br />
+        • Wenn Du mehrere Benachrichtigungen an verschiedenen Tagen erhalten hast, dann ist das Risiko hoch. Versuche den Tracker klingeln zu lassen.
     </string>
     <string name="how_does_airguard_work">Wie funktioniert AirGuard?</string>
     <string name="i_cannot_find_the_tracker">Ich kann den Tracker nicht finden</string>
-    <string name="airguard_scan_explanation">AirGuard verwendet Bluetooth, um nach Geräten zu suchen, die dir folgen.</string>
+    <string name="airguard_scan_explanation">AirGuard verwendet Bluetooth, um nach Geräten zu suchen, die Dir folgen.</string>
     <string name="airguard_detection_explanation">Mit Hilfe von Standortinformationen kann AirGuard erkennen, ob dich ein Tracker verfolgt!</string>
-    <string name="airguard_notification_explanation">Du bekommst eine Benachrichtigung, wenn dein Risiko erhöht ist. Auch die Farbe der Karte oben ändert sich in rot oder Orange.</string>
+    <string name="airguard_notification_explanation">Du bekommst eine Benachrichtigung, wenn Dein Risiko erhöht ist. Auch die Farbe der Karte oben ändert sich in Rot oder Orange.</string>
     <string name="find_sound">Spiele einen Ton ab und finde es</string>
     <string name="find_manual_scan">Scanne manuell und suche es über die Distanz</string>
     <string name="find_battery">Entferne die Batterie</string>
-    <string name="find_headline">Find und deaktiviere einen AirTag</string>
+    <string name="find_headline">Finde und deaktiviere einen AirTag</string>
     <string name="title_risk_detail">Risiko Evaluation</string>
     <string name="show_all">Alle anzeigen</string>
     <string name="tracker_detected">Tracker erkannt</string>
@@ -164,5 +164,5 @@
     <string name="app_theme_light">Hell</string>
     <string name="app_theme_system_default">System Standard</string>
     <string name="settings_metric_title">Metrisches System</string>
-    <string name="settings_metric_summary">Das metrische system wird verwendet um distanzen anzuzeigen</string>
+    <string name="settings_metric_summary">Das metrische System wird verwendet, um Distanzen anzuzeigen</string>
 </resources>


### PR DESCRIPTION
- This also includes the fix from nohn (PR #38)
- You might want to look into writing `Dich` instead of `dich` (`Du` and `Dein` is also capitalized)