### PR TITLE
Improve English "notification_help" string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,7 @@
         • Scan for the tracker manually and eventually trigger the sound.\n<br />
         • Deactivate the tracker by removing the battery.\n<br />
         • Go to the police with the tracker.\n<br />
-        • Make sure that you don’t move to a safe place before you have deactivated the tracker.\n<br />
+        • Make sure that you don’t move to another location before deactivating the tracker.\n<br />
     </string>
     <string name="i_got_a_notification_what_should_i_do">I got a notification, what should I do?</string>
 


### PR DESCRIPTION
Changes "Make sure that you don’t move to **a safe place** before **you have deactivated** the tracker." to "Make sure that you don’t move to **another location** before **deactivating** the tracker."

Telling users to avoid going to "a safe place" seems to be a mistranslation from the [German string](https://github.com/seemoo-lab/AirGuard/blob/main/app/src/main/res/values-de/strings.xml) "Stelle sicher, dass du dich nicht an einen anderen Ort begibst bevor du den Tracker gefunden hast". "Deactivating" is a shorter way to say "you have deactivated" in the sentence.