### PR TITLE
Add logo to f-droid badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://img.shields.io/github/release/seemoo-lab/AirGuard.svg?logo=github" />
   </a>
   <a href="https://f-droid.org/packages/de.seemoo.at_tracking_detection">
-    <img src="https://img.shields.io/f-droid/v/de.seemoo.at_tracking_detection.svg" />
+    <img src="https://img.shields.io/f-droid/v/de.seemoo.at_tracking_detection.svg?logo=fdroid" />
   </a>
   <a href="https://play.google.com/store/apps/details?id=de.seemoo.at_tracking_detection.release">
     <img src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Dde.seemoo.at_tracking_detection.release%26l%3DGoogle%2520Play%26m%3D%24version" />


### PR DESCRIPTION
shields.io supports the f-droid logo, thought it would be nice to have it in there to match with the other badges