### PR TITLE
fix: networkProviderEnabled check

### DIFF
--- a/app/src/main/java/de/seemoo/at_tracking_detection/detection/LocationProvider.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/detection/LocationProvider.kt
@@ -211,13 +211,15 @@ open class LocationProvider @Inject constructor(
                 handler.looper
             )
 
-            locationManager.requestLocationUpdates(
-                LocationManager.NETWORK_PROVIDER,
-                MIN_UPDATE_TIME_MS,
-                MIN_DISTANCE_METER,
-                this,
-                handler.looper
-            )
+            if (networkProviderEnabled){
+                locationManager.requestLocationUpdates(
+                    LocationManager.NETWORK_PROVIDER,
+                    MIN_UPDATE_TIME_MS,
+                    MIN_DISTANCE_METER,
+                    this,
+                    handler.looper
+                )
+            }
 
         } else if (networkProviderEnabled) {
             locationManager.requestLocationUpdates(


### PR DESCRIPTION
This additional check fixes a problem that caused the application to crash on start when no NETWORK_PROVIDER was available. This scenario is common in ROMs that do not have Google Play Services or a Location Provider installed.

fixes #131