### PR TITLE
Fix Google Play badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/f-droid/v/de.seemoo.at_tracking_detection.svg" />
   </a>
   <a href="https://play.google.com/store/apps/details?id=de.seemoo.at_tracking_detection.release">
-    <img src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Dde.seemoo.at_tracking_detection.release%26l%3DGoogle%2520Play%26m%3D%24version" />
+    <img src="https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dde.seemoo.at_tracking_detection.release%26l%3DGoogle%2520Play%26m%3D%24version" />
   </a>
   <img src="https://github.com/seemoo-lab/AirGuard/actions/workflows/android.yml/badge.svg" />
  </p>


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| ![](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplayshields.herokuapp.com%2Fplay%3Fi%3Dde.seemoo.at_tracking_detection.release%26l%3DGoogle%2520Play%26m%3D%24version) | ![](https://img.shields.io/endpoint?color=green&logo=google-play&logoColor=green&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dde.seemoo.at_tracking_detection.release%26l%3DGoogle%2520Play%26m%3D%24version) | 

The old endpoint is longer maintained and project archived:
- https://github.com/cvzi/playshields

The alternative made by the same author can simply replace the old one:
- https://github.com/cvzi/play