### PR TITLE
fix: make implicit intents safe

### DIFF
--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/dashboard/RiskDetailFragment.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/dashboard/RiskDetailFragment.kt
@@ -55,7 +55,7 @@ class RiskDetailFragment : Fragment() {
 //                Intent.ACTION_VIEW,
 //                Uri.parse("https://support.apple.com/en-us/HT212227")
 //            )
-//            startActivity(intent)
+//            startActivitySafe(intent)
 //        }
 
         view.findViewById<MaterialCardView>(R.id.card_trackers_found).setOnClickListener {

--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/onboarding/IgnoreBatteryOptimizationFragment.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/onboarding/IgnoreBatteryOptimizationFragment.kt
@@ -18,6 +18,7 @@ import androidx.fragment.app.Fragment
 import dagger.hilt.android.AndroidEntryPoint
 import de.seemoo.at_tracking_detection.R
 import de.seemoo.at_tracking_detection.databinding.FragmentIgnoreBatteryOptimizationBinding
+import de.seemoo.at_tracking_detection.util.startActivitySafe
 
 @AndroidEntryPoint
 class IgnoreBatteryOptimizationFragment : Fragment() {
@@ -64,7 +65,7 @@ class IgnoreBatteryOptimizationFragment : Fragment() {
             intent.action = Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
             intent.data = Uri.parse("package:$packageName")
         }
-        requireContext().startActivity(intent)
+        requireContext().startActivitySafe(intent)
     }
 
     companion object {

--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/onboarding/IgnoreBatteryOptimizationFragment.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/onboarding/IgnoreBatteryOptimizationFragment.kt
@@ -65,7 +65,7 @@ class IgnoreBatteryOptimizationFragment : Fragment() {
             intent.action = Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
             intent.data = Uri.parse("package:$packageName")
         }
-        requireContext().startActivitySafe(intent)
+        startActivitySafe(intent)
     }
 
     companion object {

--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/settings/InformationFragment.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/settings/InformationFragment.kt
@@ -16,6 +16,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import de.seemoo.at_tracking_detection.R
+import de.seemoo.at_tracking_detection.util.startActivitySafe
 
 class InformationFragment : Fragment() {
 
@@ -84,7 +85,7 @@ class InformationFragment : Fragment() {
                 Intent.ACTION_VIEW,
                 Uri.parse("https://twitter.com/AirGuardAndroid")
             )
-            startActivity(intent)
+            startActivitySafe(intent)
         }
     }
 
@@ -102,7 +103,7 @@ class InformationFragment : Fragment() {
 
     private fun openAttributionLink(link: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))
-        startActivity(intent)
+        startActivitySafe(intent)
     }
 
     private fun getAttributions(): List<AttributionItem> {
@@ -119,8 +120,7 @@ class InformationFragment : Fragment() {
             putExtra(Intent.EXTRA_SUBJECT, "Subject of the email")
             putExtra(Intent.EXTRA_TEXT, "Body of the email")
         }
-
-        startActivity(emailIntent)
+        startActivitySafe(emailIntent)
     }
 
 }

--- a/app/src/main/java/de/seemoo/at_tracking_detection/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/ui/settings/SettingsFragment.kt
@@ -16,6 +16,7 @@ import de.seemoo.at_tracking_detection.ATTrackingDetectionApplication
 import de.seemoo.at_tracking_detection.R
 import de.seemoo.at_tracking_detection.util.SharedPrefs
 import de.seemoo.at_tracking_detection.util.Utility
+import de.seemoo.at_tracking_detection.util.startActivitySafe
 import de.seemoo.at_tracking_detection.worker.BackgroundWorkScheduler
 import timber.log.Timber
 import javax.inject.Inject
@@ -52,7 +53,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     Intent.ACTION_VIEW,
                     Uri.parse("https://tpe.seemoo.tu-darmstadt.de/privacy-policy.html")
                 )
-                startActivity(intent)
+                startActivitySafe(intent)
                 return@OnPreferenceClickListener true
             }
 

--- a/app/src/main/java/de/seemoo/at_tracking_detection/util/SafeImplicitIntent.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/util/SafeImplicitIntent.kt
@@ -1,0 +1,24 @@
+package de.seemoo.at_tracking_detection.util
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import de.seemoo.at_tracking_detection.R
+
+inline fun Context.startActivitySafe(intent: Intent, onError: () -> Unit = { showNotAppFound() }) {
+    if (intent.resolveActivity(packageManager) != null)
+        startActivity(intent)
+    else
+        onError()
+}
+
+fun Context.showNotAppFound() {
+    val message = getString(R.string.app_handler_not_found)
+    Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun Fragment.startActivitySafe(intent: Intent, onError: (() -> Unit)? = null) {
+    val context = requireContext()
+    context.startActivitySafe(intent, onError ?: { context.showNotAppFound() })
+}

--- a/app/src/main/java/de/seemoo/at_tracking_detection/util/SafeImplicitIntent.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/util/SafeImplicitIntent.kt
@@ -1,5 +1,6 @@
 package de.seemoo.at_tracking_detection.util
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
@@ -7,10 +8,11 @@ import androidx.fragment.app.Fragment
 import de.seemoo.at_tracking_detection.R
 
 inline fun Context.startActivitySafe(intent: Intent, onError: () -> Unit = { showNotAppFound() }) {
-    if (intent.resolveActivity(packageManager) != null)
+    try {
         startActivity(intent)
-    else
+    } catch (e: ActivityNotFoundException) {
         onError()
+    }
 }
 
 fun Context.showNotAppFound() {
@@ -18,7 +20,9 @@ fun Context.showNotAppFound() {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
 }
 
-fun Fragment.startActivitySafe(intent: Intent, onError: (() -> Unit)? = null) {
-    val context = requireContext()
-    context.startActivitySafe(intent, onError ?: { context.showNotAppFound() })
+inline fun Fragment.startActivitySafe(
+    intent: Intent,
+    onError: () -> Unit = { context?.showNotAppFound() }
+) {
+    context?.startActivitySafe(intent, onError)
 }

--- a/app/src/main/java/de/seemoo/at_tracking_detection/util/ble/BLEScanner.kt
+++ b/app/src/main/java/de/seemoo/at_tracking_detection/util/ble/BLEScanner.kt
@@ -13,6 +13,7 @@ import de.seemoo.at_tracking_detection.ATTrackingDetectionApplication
 import de.seemoo.at_tracking_detection.database.models.device.DeviceManager
 import de.seemoo.at_tracking_detection.detection.LocationRequester
 import de.seemoo.at_tracking_detection.util.Utility
+import de.seemoo.at_tracking_detection.util.startActivitySafe
 import timber.log.Timber
 
 
@@ -159,6 +160,6 @@ object BLEScanner {
     fun openBluetoothSettings(context: Context) {
         val intentOpenBluetoothSettings = Intent()
         intentOpenBluetoothSettings.action = Settings.ACTION_BLUETOOTH_SETTINGS
-        context.startActivity(intentOpenBluetoothSettings)
+        context.startActivitySafe(intentOpenBluetoothSettings)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
 
     <string name="settings_information_contact_title">Information &amp; Contact</string>
     <string name="settings_information_contact_summary">Get information about us</string>
+    <string name="app_handler_not_found">App for opening this content isn\'t found</string>
 
     <string name="settings_delete_study_data_title">Delete study data</string>
     <string name="settings_delete_study_data_summary">Request deletion of study data</string>


### PR DESCRIPTION
The current code lacks verification of whether the implicit intent is fulfilled. In my device, I don't have any browser installed and, consequently, when I attempt to trigger an implicit intent by clicking a button to open a URL, the app crashes.

These modifications introduce comprehensive support to enhance the safety of implicit intents. This update addresses the issue by implementing a check to initiate the implicit intent securely. In cases where the implicit intent fails to start, a toast notification is displayed to the user, indicating the absence of an application capable of opening the content. (Note: This error handling can be customized using the onError lambda within the method, although the current approach aligns with the standard practice adopted by most applications.)

